### PR TITLE
Fixed isMono() to return the implied result (true if mono, instead of… … true if stereo)

### DIFF
--- a/src/ofxCameraAnaglyph.cpp
+++ b/src/ofxCameraAnaglyph.cpp
@@ -135,7 +135,7 @@ bool ofxCameraAnaglyph::isStereo() {
 
 //--------------------------------------------------------------
 bool ofxCameraAnaglyph::isMono() {
-    return bStereo;
+    return !bStereo;
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
Fixed isMono() to return the correct implied result (true if mono, instead of… … true if stereo).. Before, isStereo() and isMono() returned the same result.
